### PR TITLE
Add instructions for installing Rust/Cargo in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ You can contribute to the AI Pocket Reference project in several ways:
 
 2. **Install `mdbook` and Required Preprocessors**
 
-   > **NOTE**
+   > **NOTE**\
    > This step requires Rust and Cargo to be installed on your machine.
    > If not yet installed, run the command provided under "Install Rust/Cargo"
 
@@ -156,7 +156,7 @@ There are two ways to include code in your pocket reference:
    - Reference these notebooks from your pocket reference using the helper
      `{{#colab <book>/<notebook-title>.ipynb}}`
 
-     > **NOTE**
+     > **NOTE**\
      > Ensure that you're notebook has been successfully merged into the supplementary
      > code Github repository. Otherwise, the Google colab link will not work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,14 @@ You can contribute to the AI Pocket Reference project in several ways:
 
 2. **Install `mdbook` and Required Preprocessors**
 
+   > [!NOTE]
+   > This step requires Rust and Cargo to be installed on your machine.
+   > If not yet installed, run the command provided under "Install Rust/Cargo"
+
    ```bash
+   # Install Rust/Cargo
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
    # Install mdbook and required preprocessors
    cargo install mdbook
    cargo install mdbook-ai-pocket-reference    # For aipr preprocessors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ You can contribute to the AI Pocket Reference project in several ways:
 
 2. **Install `mdbook` and Required Preprocessors**
 
-   > [!NOTE]
+   > **NOTE**
    > This step requires Rust and Cargo to be installed on your machine.
    > If not yet installed, run the command provided under "Install Rust/Cargo"
 
@@ -156,7 +156,7 @@ There are two ways to include code in your pocket reference:
    - Reference these notebooks from your pocket reference using the helper
      `{{#colab <book>/<notebook-title>.ipynb}}`
 
-     > [!NOTE]
+     > **NOTE**
      > Ensure that you're notebook has been successfully merged into the supplementary
      > code Github repository. Otherwise, the Google colab link will not work.
 


### PR DESCRIPTION
Our Contributing Guide assumes that Rust/Cargo is installed on the contributor's machine. Adding instructions for that installation should that not be the case.

Updated Contribution Guide:

![image](https://github.com/user-attachments/assets/0d5b15ed-d906-4ebe-9af1-fba62814f863)
