### PR TITLE
Add missing preprocessors in `book.toml` of several books

### DIFF
--- a/books/cv/book.toml
+++ b/books/cv/book.toml
@@ -16,6 +16,13 @@ create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
 extra-watch-dirs = []             # directories to watch for triggering builds
 
+# preprocessors
+[preprocessor.github-authors]
+command = "mdbook-github-authors"
+
+[preprocessor.ai-pocket-reference]
+command = "mdbook-ai-pocket-reference"
+after = [ "github-authors" ]
 
 [output.html]
 mathjax-support = true

--- a/books/fl/book.toml
+++ b/books/fl/book.toml
@@ -16,6 +16,14 @@ create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
 extra-watch-dirs = []             # directories to watch for triggering builds
 
+# preprocessors
+[preprocessor.github-authors]
+command = "mdbook-github-authors"
+
+[preprocessor.ai-pocket-reference]
+command = "mdbook-ai-pocket-reference"
+after = [ "github-authors" ]
+
 
 [output.html]
 mathjax-support = true

--- a/books/fundamentals/book.toml
+++ b/books/fundamentals/book.toml
@@ -16,6 +16,14 @@ create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
 extra-watch-dirs = []             # directories to watch for triggering builds
 
+# preprocessors
+[preprocessor.github-authors]
+command = "mdbook-github-authors"
+
+[preprocessor.ai-pocket-reference]
+command = "mdbook-ai-pocket-reference"
+after = [ "github-authors" ]
+
 
 [output.html]
 mathjax-support = true

--- a/books/responsible_ai/book.toml
+++ b/books/responsible_ai/book.toml
@@ -19,6 +19,14 @@ create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
 extra-watch-dirs = []             # directories to watch for triggering builds
 
+# preprocessors
+[preprocessor.github-authors]
+command = "mdbook-github-authors"
+
+[preprocessor.ai-pocket-reference]
+command = "mdbook-ai-pocket-reference"
+after = [ "github-authors" ]
+
 
 [output.html]
 mathjax-support = true

--- a/books/rl/book.toml
+++ b/books/rl/book.toml
@@ -16,6 +16,14 @@ create-missing = true             # whether or not to create missing pages
 use-default-preprocessors = true  # use the default preprocessors
 extra-watch-dirs = []             # directories to watch for triggering builds
 
+# preprocessors
+[preprocessor.github-authors]
+command = "mdbook-github-authors"
+
+[preprocessor.ai-pocket-reference]
+command = "mdbook-ai-pocket-reference"
+after = [ "github-authors" ]
+
 
 [output.html]
 mathjax-support = true


### PR DESCRIPTION
Several books were missing the specification of our preprocessors in their respective `book.toml` files. This PR addresses this issue.