### PR TITLE
[Fix] Pin `mdbook` version to 0.4.44 in CLI; update CONTRIBUTING.md

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install mdbook if needed
         run: |
-          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4.44" mdbook)
+          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "0.4.44" mdbook)
           cargo install mdbook-ai-pocket-reference
           cargo install mdbook-github-authors
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install mdbook if needed
+      - name: Install mdbook if needed  # Pin of mdbook should match the version used to generate theme.bbs template
         run: |
           (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "0.4.44" mdbook)
           cargo install mdbook-ai-pocket-reference

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,16 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install mdbook if needed  # Pin of mdbook should match the version used to generate theme.bbs template
         run: |
           (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "0.4.44" mdbook)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Install mdbook if needed  # Pin of mdbook should match the version used to generate theme.bbs template
         run: |
           (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "0.4.44" mdbook)
-          cargo install mdbook-ai-pocket-reference
-          cargo install mdbook-github-authors
+          (test -x $HOME/.cargo/bin/mdbook-ai-pocket-reference ||cargo install mdbook-ai-pocket-reference)
+          (test -x $HOME/.cargo/bin/mdbook-github-authors || cargo install mdbook-github-authors)
 
       - name: Build books
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install mdbook if needed
         run: |
-          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4.44" mdbook)
           cargo install mdbook-ai-pocket-reference
           cargo install mdbook-github-authors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ You can contribute to the AI Pocket Reference project in several ways:
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
    # Install mdbook and required preprocessors
-   cargo install mdbook
+   cargo install --vers "0.4.44" mdbook  # Pin required due to our custom themes
    cargo install mdbook-ai-pocket-reference    # For aipr preprocessors
    cargo install mdbook-github-authors  # For tracking contributors
    ```


### PR DESCRIPTION
Our customized theme.bbs file was derived from `mdbook v0.4.44`. The crate has since been updated to `v0.4.47` and apparently its breaking:

- the button to change the theme doesn't work
- also noticed inline code styling has gone wonky

Immediate fix in this PR is to pin the `mdbook` version to `0.4.44` in our Github action. Will open a new issue to update our theme to latest `mdbook` version. We need to think of how we can regularly update this file.

UPDATE:
Here is the issue #125 