### PR TITLE
[Fix] links to README.md should be `index.html` instead.

### DIFF
--- a/books/nlp/src/llms/agents/README.md
+++ b/books/nlp/src/llms/agents/README.md
@@ -62,7 +62,7 @@ and frequencies of use. This is the case with LlamaIndex's
 
 The underlying LLM powering the agent's every move can be
 any language model, including the notable models listed in
-[the pocket references of notable models](../../models/README.md)
+[the pocket references of notable models](../../models/index.html)
 (e.g., [Llama-3](../../models/llama_3.md),
 [DeepSeek-R1](../../models/deepseek_r1.md), etc.).
 
@@ -117,7 +117,7 @@ Lastly, more work and time are needed to foster community trust
 in the viability of agents for everyday life.
 
 Advances have been made to address these perceived shortcomings,
-with the foremost technique being [fine-tuning](../fine_tuning/README.md).
+with the foremost technique being [fine-tuning](../fine_tuning/index.html).
 Supervised fine-tuning with instructions
 [(Zhang et al., 2024)](https://arxiv.org/abs/2308.10792),
 alignment and safety fine-tuning


### PR DESCRIPTION
# [NLP] `Agents`

<!-- Example: [NLP] Add Transformers Pocket Reference -->
<!-- Example: [CV] Fix CNN Architecture Diagram -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] New Pocket Reference
- [x] Edit to Existing Pocket Reference
- [ ] Other (please describe):

## Related Issue

<!-- Link to the related issue -->

Fixes #

## Book

<!-- Indicate which book this PR affects -->

- [ ] fundamentals
- [x] nlp
- [ ] cv
- [ ] rl
- [ ] fl
- [ ] responsible_ai

## Description

Fixes issue with links that point to README.md files. `mdbook` processes these and turns them into `index.html` by default.