### PR TITLE
Update github actions to install lateste versions of preprocessors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,12 @@ jobs:
           (test -x $HOME/.cargo/bin/mdbook-ai-pocket-reference ||cargo install mdbook-ai-pocket-reference)
           (test -x $HOME/.cargo/bin/mdbook-github-authors || cargo install mdbook-github-authors)
 
+      - name: Install cargo-update
+        run: cargo install cargo-update
+
+      - name: Update mdbook plugins if needed
+        run: cargo install-update mdbook-ai-pocket-reference mdbook-github-authors
+
       - name: Build books
         run: |
           mdbook build books/nlp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,5 @@ repos:
           "--skip=*/algolia.js",
           "--ignore-words-list",
           "rouge",
+          "crate"
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,5 @@ repos:
         [
           "--skip=*/algolia.js",
           "--ignore-words-list",
-          "rouge",
-          "crate"
+          "rouge,crate",
         ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,22 @@ We use several mdBook preprocessors to enhance our pocket references:
 - [mdbook-github-authors](https://github.com/VectorInstitute/mdbook-github-authors)
   — for listing Contributors of a pocket reference
 
+### Updating mdBook Preprocessors
+
+To update our preprocessors, we make use of the `cargo-update` crate. To install
+it use the command below:
+
+```sh
+cargo install cargo-update
+```
+
+After installation, you can run the command below to update our preprocessors
+when needed:
+
+```sh
+cargo install-update mdbook-ai-pocket-reference mdbook-github-authors
+```
+
 ### Adding the AI Pocket Reference Header
 
 To add the default header to your pocket reference, you can need to use the


### PR DESCRIPTION
This PR updates the release workflow to check if there's an update to any of our preprocessors. In this instance, `mdbook-ai-pocket-reference` has been updated so that markdown links open in a new browser tab.

Instructions for updating preprocessors are also added to the CONTRIBUTING.md file